### PR TITLE
Bulk Geocode patch to release version 2.5.x

### DIFF
--- a/lib/template/address-json.php
+++ b/lib/template/address-json.php
@@ -1,30 +1,73 @@
 <?php
-	$aFilteredPlaces = array();
+    
+    function get_filtered_place($aPlace, $bAsPoints){
+        $aFilteredPlaces = array();
+        if (isset($aPlace['place_id'])) $aFilteredPlaces['place_id'] = $aPlace['place_id'];
+        $aFilteredPlaces['licence'] = "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright";
+        $sOSMType = ($aPlace['osm_type'] == 'N'?'node':($aPlace['osm_type'] == 'W'?'way':($aPlace['osm_type'] == 'R'?'relation':'')));
+        if ($sOSMType)
+        {
+            $aFilteredPlaces['osm_type'] = $sOSMType;
+            $aFilteredPlaces['osm_id'] = $aPlace['osm_id'];
+        }
+        if (isset($aPlace['lat'])) $aFilteredPlaces['lat'] = $aPlace['lat'];
+        if (isset($aPlace['lon'])) $aFilteredPlaces['lon'] = $aPlace['lon'];
+        $aFilteredPlaces['display_name'] = $aPlace['langaddress'];
+        if (isset($aPlace['aAddress'])) $aFilteredPlaces['address'] = $aPlace['aAddress'];
+        if (isset($aPlace['sExtraTags'])) $aFilteredPlaces['extratags'] = $aPlace['sExtraTags'];
+        if (isset($aPlace['sNameDetails'])) $aFilteredPlaces['namedetails'] = $aPlace['sNameDetails'];
 
-	if (!sizeof($aPlace))
-	{
-		if (isset($sError))
-			$aFilteredPlaces['error'] = $sError;
-		else
-			$aFilteredPlaces['error'] = 'Unable to geocode';
-	}
-	else
-	{
-		if (isset($aPlace['place_id'])) $aFilteredPlaces['place_id'] = $aPlace['place_id'];
-		$aFilteredPlaces['licence'] = "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright";
-		$sOSMType = ($aPlace['osm_type'] == 'N'?'node':($aPlace['osm_type'] == 'W'?'way':($aPlace['osm_type'] == 'R'?'relation':'')));
-                if ($sOSMType)
-                {
-                        $aFilteredPlaces['osm_type'] = $sOSMType;
-                        $aFilteredPlaces['osm_id'] = $aPlace['osm_id'];
-                }
-                if (isset($aPlace['lat'])) $aFilteredPlaces['lat'] = $aPlace['lat'];
-                if (isset($aPlace['lon'])) $aFilteredPlaces['lon'] = $aPlace['lon'];
-		$aFilteredPlaces['display_name'] = $aPlace['langaddress'];
-		if (isset($aPlace['aAddress'])) $aFilteredPlaces['address'] = $aPlace['aAddress'];
-		if (isset($aPlace['sExtraTags'])) $aFilteredPlaces['extratags'] = $aPlace['sExtraTags'];
-		if (isset($aPlace['sNameDetails'])) $aFilteredPlaces['namedetails'] = $aPlace['sNameDetails'];
-	}
+        if (isset($aPlace['aBoundingBox']))
+        {
+            $aFilteredPlaces['boundingbox'] = $aPlace['aBoundingBox'];
 
-	javascript_renderData($aFilteredPlaces);
+            if (isset($aPlace['aPolyPoints']) && $bAsPoints)
+            {
+                $aFilteredPlaces['polygonpoints'] = $aPlace['aPolyPoints'];
+            }
+        }
+
+        if (isset($aPlace['asgeojson']))
+        {
+            $aFilteredPlaces['geojson'] = json_decode($aPlace['asgeojson']);
+        }
+
+        if (isset($aPlace['assvg']))
+        {
+            $aFilteredPlaces['svg'] = $aPlace['assvg'];
+        }
+
+        if (isset($aPlace['astext']))
+        {
+            $aFilteredPlaces['geotext'] = $aPlace['astext'];
+        }
+
+        if (isset($aPlace['askml']))
+        {
+            $aFilteredPlaces['geokml'] = $aPlace['askml'];
+        }
+        return $aFilteredPlaces;
+    }
+
+    // Is $aPlace set?  This is set if a single lat/lon request was executed sucessfully
+    $aFilteredPlaces = array();
+    if(isset($aPlace) && sizeof($aPlace))
+    {
+        $aFilteredPlaces = get_filtered_place($aPlace, $bAsPoints);
+    }
+    // Is $aPlaces set?  This is set if a batch lat/lon request was executed sucessfully
+    else if(isset($aPlaces) && sizeof($aPlaces)){
+        for($i = 0; $i < count($aPlaces); $i++){
+            $aFilteredPlaces[$i] = get_filtered_place($aPlaces[$i], $bAsPoints);
+        }
+    }
+    // Otherwise, its a failure
+    else{
+        if (isset($sError))
+            $aFilteredPlaces['error'] = $sError;
+        else
+            $aFilteredPlaces['error'] = 'Unable to geocode';
+    }
+
+    javascript_renderData($aFilteredPlaces);
 

--- a/lib/template/address-json.php
+++ b/lib/template/address-json.php
@@ -17,35 +17,6 @@
         if (isset($aPlace['sExtraTags'])) $aFilteredPlaces['extratags'] = $aPlace['sExtraTags'];
         if (isset($aPlace['sNameDetails'])) $aFilteredPlaces['namedetails'] = $aPlace['sNameDetails'];
 
-        if (isset($aPlace['aBoundingBox']))
-        {
-            $aFilteredPlaces['boundingbox'] = $aPlace['aBoundingBox'];
-
-            if (isset($aPlace['aPolyPoints']) && $bAsPoints)
-            {
-                $aFilteredPlaces['polygonpoints'] = $aPlace['aPolyPoints'];
-            }
-        }
-
-        if (isset($aPlace['asgeojson']))
-        {
-            $aFilteredPlaces['geojson'] = json_decode($aPlace['asgeojson']);
-        }
-
-        if (isset($aPlace['assvg']))
-        {
-            $aFilteredPlaces['svg'] = $aPlace['assvg'];
-        }
-
-        if (isset($aPlace['astext']))
-        {
-            $aFilteredPlaces['geotext'] = $aPlace['astext'];
-        }
-
-        if (isset($aPlace['askml']))
-        {
-            $aFilteredPlaces['geokml'] = $aPlace['askml'];
-        }
         return $aFilteredPlaces;
     }
 

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -21,6 +21,45 @@
 	$oDB =& getDB();
 	ini_set('memory_limit', '200M');
 
+	function get_place_from_lookup($aLookup, $oDB){
+		$bAsPoints = false;
+		$bAsGeoJSON = (boolean)isset($_GET['polygon_geojson']) && $_GET['polygon_geojson'];
+		$bAsKML = (boolean)isset($_GET['polygon_kml']) && $_GET['polygon_kml'];
+		$bAsSVG = (boolean)isset($_GET['polygon_svg']) && $_GET['polygon_svg'];
+		$bAsText = (boolean)isset($_GET['polygon_text']) && $_GET['polygon_text'];
+
+		// Polygon simplification threshold (optional)
+		$fThreshold = 0.0;
+		if (isset($_GET['polygon_threshold'])) $fThreshold = (float)$_GET['polygon_threshold'];
+
+		$oPlaceLookup = new PlaceLookup($oDB);
+		$aLanguagePref = getPreferredLanguages();
+
+		$oPlaceLookup->setLanguagePreference($aLanguagePref);
+		$oPlaceLookup->setIncludeAddressDetails(getParamBool('addressdetails', true));
+		$oPlaceLookup->setIncludeExtraTags(getParamBool('extratags', false));
+		$oPlaceLookup->setIncludeNameDetails(getParamBool('namedetails', false));
+
+		$aPlace = $oPlaceLookup->lookupPlace($aLookup);
+
+		$oPlaceLookup->setIncludePolygonAsPoints($bAsPoints);
+		$oPlaceLookup->setIncludePolygonAsText($bAsText);
+		$oPlaceLookup->setIncludePolygonAsGeoJSON($bAsGeoJSON);
+		$oPlaceLookup->setIncludePolygonAsKML($bAsKML);
+		$oPlaceLookup->setIncludePolygonAsSVG($bAsSVG);
+		$oPlaceLookup->setPolygonSimplificationThreshold($fThreshold);
+
+		$fRadius = $fDiameter = getResultDiameter($aPlace);
+		$aOutlineResult = $oPlaceLookup->getOutlines($aPlace['place_id'], $aPlace['lon'], $aPlace['lat'], $fRadius);
+
+		if ($aOutlineResult)
+		{
+			$aPlace = array_merge($aPlace, $aOutlineResult);
+		}
+		return $aPlace;
+	}
+
+
 	// Format for output
 	$sOutputFormat = 'xml';
 	if (isset($_GET['format']) && ( $_GET['format'] == 'html' || $_GET['format'] == 'xml' || $_GET['format'] == 'json' || $_GET['format'] == 'jsonv2'))
@@ -56,23 +95,38 @@
 
 	if ($aLookup)
 	{
-		$oPlaceLookup = new PlaceLookup($oDB);
-		$oPlaceLookup->setLanguagePreference($aLangPrefOrder);
-		$oPlaceLookup->setIncludeAddressDetails(getParamBool('addressdetails', true));
-		$oPlaceLookup->setIncludeExtraTags(getParamBool('extratags', false));
-		$oPlaceLookup->setIncludeNameDetails(getParamBool('namedetails', false));
-
-		$aPlace = $oPlaceLookup->lookupPlace($aLookup);
+		$aPlace = get_place_from_lookup($aLookup, $oDB);
 	}
 	else
 	{
 		$aPlace = null;
 	}
-
+	// Locations is a url encoded request parameter that contains json of the following format:
+	// {"locations":[{"lat":30, "lon":-90}, {"lat":40, "lon":50}]}
+	if(isset($_GET['locations'])){
+		$locJson = $_GET['locations'];
+		$aPlaces = array();
+		if(json_decode($locJson) != NULL){
+			$locs = json_decode($locJson);
+			for($i = 0; $i < count($locs->locations); $i++){
+				$oReverseGeocode = new ReverseGeocode($oDB);
+				$oReverseGeocode->setLanguagePreference($aLangPrefOrder);
+				$oReverseGeocode->setLatLon($locs->locations[$i]->lat, $locs->locations[$i]->lon);
+				$aLookup = $oReverseGeocode->lookup();
+				if($aLookup){
+					$aPlaces[$i] = get_place_from_lookup($aLookup, $oDB);
+				}
+				else{
+					$aPlaces[$i] = null;
+				}
+			}
+		}
+	}
 
 	if (CONST_Debug)
 	{
 		var_dump($aPlace);
+		if(isset($aPlaces)) var_dump($aPlaces);
 		exit;
 	}
 

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -41,21 +41,7 @@
 		$oPlaceLookup->setIncludeNameDetails(getParamBool('namedetails', false));
 
 		$aPlace = $oPlaceLookup->lookupPlace($aLookup);
-
-		$oPlaceLookup->setIncludePolygonAsPoints($bAsPoints);
-		$oPlaceLookup->setIncludePolygonAsText($bAsText);
-		$oPlaceLookup->setIncludePolygonAsGeoJSON($bAsGeoJSON);
-		$oPlaceLookup->setIncludePolygonAsKML($bAsKML);
-		$oPlaceLookup->setIncludePolygonAsSVG($bAsSVG);
-		$oPlaceLookup->setPolygonSimplificationThreshold($fThreshold);
-
-		$fRadius = $fDiameter = getResultDiameter($aPlace);
-		$aOutlineResult = $oPlaceLookup->getOutlines($aPlace['place_id'], $aPlace['lon'], $aPlace['lat'], $fRadius);
-
-		if ($aOutlineResult)
-		{
-			$aPlace = array_merge($aPlace, $aOutlineResult);
-		}
+		
 		return $aPlace;
 	}
 


### PR DESCRIPTION
Adds the ability for Nominatim to do bulk reverse geocode requests.  This is experimental, no unit tests, and only works for JSON request type.

locations are requested by passing a GET parameter named "locations", the value is url-encoded JSON with the following format:

{"locations":[{"lat":30, "lon":-90}, {"lat":40, "lon":50}]}